### PR TITLE
Fix https://issues.jenkins-ci.org/browse/JENKINS-41507

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pluginusage/JobsPerPlugin.java
+++ b/src/main/java/org/jenkinsci/plugins/pluginusage/JobsPerPlugin.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.plugins.pluginusage;
 
 import hudson.PluginWrapper;
-import hudson.model.Project;
+import hudson.model.AbstractProject;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -10,19 +10,19 @@ import java.util.List;
 public class JobsPerPlugin {
 	
 	private PluginWrapper plugin;
-	private HashMap<String, Project> jobMap = new HashMap<String, Project>();
+	private HashMap<String, AbstractProject> jobMap = new HashMap<String, AbstractProject>();
 	
 	
 	public JobsPerPlugin(PluginWrapper plugin) {
 		this.plugin = plugin;
 	}
 	
-	public void addProject(Project project) {
+	public void addProject(AbstractProject project) {
 		this.jobMap.put(project.getDisplayName(), project);
 	}
 	
-	public List<Project> getProjects() {
-		ArrayList<Project> projects = new ArrayList<Project>();
+	public List<AbstractProject> getProjects() {
+		ArrayList<AbstractProject> projects = new ArrayList<AbstractProject>();
 		projects.addAll(jobMap.values());
 		
 		return projects;

--- a/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/BuildWrapperJobAnalyzer.java
+++ b/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/BuildWrapperJobAnalyzer.java
@@ -3,9 +3,11 @@ package org.jenkinsci.plugins.pluginusage.analyzer;
 import hudson.DescriptorExtensionList;
 import hudson.PluginWrapper;
 import hudson.model.Descriptor;
-import hudson.model.Project;
+import hudson.model.AbstractProject;
+import hudson.model.BuildableItemWithBuildWrappers;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.Builder;
+import hudson.util.DescribableList;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -24,28 +26,31 @@ public class BuildWrapperJobAnalyzer extends JobAnalyzer{
 		}
 	}
 	
-	protected void doJobAnalyze(Project item, HashMap<PluginWrapper, JobsPerPlugin> mapJobsPerPlugin)
+	protected void doJobAnalyze(AbstractProject item, HashMap<PluginWrapper, JobsPerPlugin> mapJobsPerPlugin)
 	{
 		super.doJobAnalyze(null, mapJobsPerPlugin);
-		Map<Descriptor<BuildWrapper>,BuildWrapper> buildWrappers = item.getBuildWrappers();
-	    for (Map.Entry<Descriptor<BuildWrapper>,BuildWrapper>  entry : buildWrappers.entrySet())
+		if (item instanceof BuildableItemWithBuildWrappers)
 		{
-		    PluginWrapper usedPlugin = getUsedPlugin(entry.getKey().clazz);
-		    if(usedPlugin!=null)
-		    {
-		    	JobsPerPlugin jobsPerPlugin = mapJobsPerPlugin.get(usedPlugin);
-		    	if(jobsPerPlugin!=null)
-		    	{
-		    		jobsPerPlugin.addProject(item);
-		    	}
-		    	else
-		    	{
-		    		JobsPerPlugin jobsPerPlugin2 = new JobsPerPlugin(usedPlugin);
-		    		jobsPerPlugin2.addProject(item);
-		    		mapJobsPerPlugin.put(usedPlugin, jobsPerPlugin2);
-		    	}
-		    }
+			DescribableList<BuildWrapper,Descriptor<BuildWrapper>> buildWrappers = ((BuildableItemWithBuildWrappers)item).getBuildWrappersList();
+			Map<Descriptor<BuildWrapper>,BuildWrapper> map = buildWrappers.toMap();
+			for (Map.Entry<Descriptor<BuildWrapper>,BuildWrapper> entry : map.entrySet())
+			{
+				PluginWrapper usedPlugin = getUsedPlugin(entry.getKey().clazz);
+				if(usedPlugin!=null)
+				{
+					JobsPerPlugin jobsPerPlugin = mapJobsPerPlugin.get(usedPlugin);
+					if(jobsPerPlugin!=null)
+					{
+						jobsPerPlugin.addProject(item);
+					}
+					else
+					{
+						JobsPerPlugin jobsPerPlugin2 = new JobsPerPlugin(usedPlugin);
+						jobsPerPlugin2.addProject(item);
+						mapJobsPerPlugin.put(usedPlugin, jobsPerPlugin2);
+					}
+				}
+			}
 		}
 	}
-
 }

--- a/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/BuilderJobAnalyzer.java
+++ b/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/BuilderJobAnalyzer.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.pluginusage.analyzer;
 import hudson.DescriptorExtensionList;
 import hudson.PluginWrapper;
 import hudson.model.Descriptor;
+import hudson.model.AbstractProject;
 import hudson.model.Project;
 import hudson.tasks.Builder;
 
@@ -25,28 +26,31 @@ public class BuilderJobAnalyzer extends JobAnalyzer{
 		}
 	}
 	
-	protected void doJobAnalyze(Project item, HashMap<PluginWrapper, JobsPerPlugin> mapJobsPerPlugin)
+	protected void doJobAnalyze(AbstractProject item, HashMap<PluginWrapper, JobsPerPlugin> mapJobsPerPlugin)
 	{	
 		super.doJobAnalyze(null, mapJobsPerPlugin);
-		List<Builder> builders = item.getBuilders();
-	    for(Builder builder: builders)
-	    {
-	    	PluginWrapper usedPlugin = getUsedPlugin(builder.getDescriptor().clazz);
-		    if(usedPlugin!=null)
-		    {
-		    	JobsPerPlugin jobsPerPlugin = mapJobsPerPlugin.get(usedPlugin);
-		    	if(jobsPerPlugin!=null)
-		    	{
-		    		jobsPerPlugin.addProject(item);
-		    	}
-		    	else
-		    	{
-		    		JobsPerPlugin jobsPerPlugin2 = new JobsPerPlugin(usedPlugin);
-		    		jobsPerPlugin2.addProject(item);
-		    		mapJobsPerPlugin.put(usedPlugin, jobsPerPlugin2);
-		    	}
-		    }
-	    }
+                if (item instanceof Project)
+                {
+                    List<Builder> builders = ((Project)item).getBuilders();
+                    for(Builder builder: builders)
+                    {
+                        PluginWrapper usedPlugin = getUsedPlugin(builder.getDescriptor().clazz);
+                        if(usedPlugin!=null)
+                        {
+                            JobsPerPlugin jobsPerPlugin = mapJobsPerPlugin.get(usedPlugin);
+                            if(jobsPerPlugin!=null)
+                            {
+                                    jobsPerPlugin.addProject(item);
+                            }
+                            else
+                            {
+                                    JobsPerPlugin jobsPerPlugin2 = new JobsPerPlugin(usedPlugin);
+                                    jobsPerPlugin2.addProject(item);
+                                    mapJobsPerPlugin.put(usedPlugin, jobsPerPlugin2);
+                            }
+                        }
+                    }
+                }
 	}
 
 }

--- a/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/JobAnalyzer.java
+++ b/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/JobAnalyzer.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import org.jenkinsci.plugins.pluginusage.JobsPerPlugin;
 
 import hudson.PluginWrapper;
-import hudson.model.Project;
+import hudson.model.AbstractProject;
 import jenkins.model.Jenkins;
 
 
@@ -19,7 +19,7 @@ public abstract class JobAnalyzer{
 		return instance.getPluginManager().whichPlugin(clazz);
 	}
 
-	protected void doJobAnalyze(Project item, HashMap<PluginWrapper, JobsPerPlugin> mapJobsPerPlugin)
+	protected void doJobAnalyze(AbstractProject item, HashMap<PluginWrapper, JobsPerPlugin> mapJobsPerPlugin)
 	{
 		for(PluginWrapper plugin: plugins)
 		{

--- a/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/JobCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/JobCollector.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.plugins.pluginusage.analyzer;
 
 import hudson.PluginWrapper;
-import hudson.model.Project;
+import hudson.model.AbstractProject;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -27,9 +27,9 @@ public class JobCollector {
 	public HashMap<PluginWrapper, JobsPerPlugin> getJobsPerPlugin()
 	{
 		HashMap<PluginWrapper, JobsPerPlugin> mapJobsPerPlugin = new HashMap<PluginWrapper, JobsPerPlugin>();
-		List<Project> allItems = Jenkins.getInstance().getAllItems(Project.class);
+		List<AbstractProject> allItems = Jenkins.getInstance().getAllItems(AbstractProject.class);
 		
-		for(Project item: allItems)
+		for(AbstractProject item: allItems)
 		{
 			for(JobAnalyzer analyser: analysers)
 			{
@@ -40,7 +40,7 @@ public class JobCollector {
 	}
 	
 	public int getNumberOfJobs() {
-		List<Project> allItems = Jenkins.getInstance().getAllItems(Project.class);
+		List<AbstractProject> allItems = Jenkins.getInstance().getAllItems(AbstractProject.class);
 		return allItems.size();	
 	}
 	

--- a/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/PropertiesJobAnalyzer.java
+++ b/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/PropertiesJobAnalyzer.java
@@ -3,7 +3,7 @@ package org.jenkinsci.plugins.pluginusage.analyzer;
 import hudson.PluginWrapper;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
-import hudson.model.Project;
+import hudson.model.AbstractProject;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -14,7 +14,7 @@ import org.jenkinsci.plugins.pluginusage.JobsPerPlugin;
 public class PropertiesJobAnalyzer extends JobAnalyzer{
 	
 
-	protected void doJobAnalyze(Project item, HashMap<PluginWrapper, JobsPerPlugin> mapJobsPerPlugin)
+	protected void doJobAnalyze(AbstractProject item, HashMap<PluginWrapper, JobsPerPlugin> mapJobsPerPlugin)
 	{	
 		Map<JobPropertyDescriptor,JobProperty> properties = item.getProperties();
 		for (Map.Entry<JobPropertyDescriptor,JobProperty> entry : properties.entrySet())

--- a/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/PublisherJobAnalyzer.java
+++ b/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/PublisherJobAnalyzer.java
@@ -3,7 +3,7 @@ package org.jenkinsci.plugins.pluginusage.analyzer;
 import hudson.DescriptorExtensionList;
 import hudson.PluginWrapper;
 import hudson.model.Descriptor;
-import hudson.model.Project;
+import hudson.model.AbstractProject;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.Publisher;
 import hudson.util.DescribableList;
@@ -25,7 +25,7 @@ public class PublisherJobAnalyzer extends JobAnalyzer{
 		}
 	}
 
-	protected void doJobAnalyze(Project item, HashMap<PluginWrapper, JobsPerPlugin> mapJobsPerPlugin)
+	protected void doJobAnalyze(AbstractProject item, HashMap<PluginWrapper, JobsPerPlugin> mapJobsPerPlugin)
 	{	
 		super.doJobAnalyze(null, mapJobsPerPlugin);
 		DescribableList<Publisher,Descriptor<Publisher>> publisherList = item.getPublishersList();

--- a/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/SCMJobAnalyzer.java
+++ b/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/SCMJobAnalyzer.java
@@ -3,7 +3,7 @@ package org.jenkinsci.plugins.pluginusage.analyzer;
 import hudson.DescriptorExtensionList;
 import hudson.PluginWrapper;
 import hudson.model.Descriptor;
-import hudson.model.Project;
+import hudson.model.AbstractProject;
 import hudson.scm.SCMDescriptor;
 import hudson.scm.SCM;
 import hudson.tasks.BuildWrapper;
@@ -24,7 +24,7 @@ public class SCMJobAnalyzer extends JobAnalyzer{
 		}
 	}
 	
-	protected void doJobAnalyze(Project item, HashMap<PluginWrapper, JobsPerPlugin> mapJobsPerPlugin)
+	protected void doJobAnalyze(AbstractProject item, HashMap<PluginWrapper, JobsPerPlugin> mapJobsPerPlugin)
 	{		
 		super.doJobAnalyze(null, mapJobsPerPlugin);
 		PluginWrapper scmPlugin = getUsedPlugin(item.getScm().getDescriptor().clazz);

--- a/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/TriggerJobAnalyzer.java
+++ b/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/TriggerJobAnalyzer.java
@@ -3,7 +3,7 @@ package org.jenkinsci.plugins.pluginusage.analyzer;
 import hudson.DescriptorExtensionList;
 import hudson.PluginWrapper;
 import hudson.model.Descriptor;
-import hudson.model.Project;
+import hudson.model.AbstractProject;
 import hudson.tasks.BuildWrapper;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
@@ -25,7 +25,7 @@ public class TriggerJobAnalyzer extends JobAnalyzer{
 		}
 	}
 
-	protected void doJobAnalyze(Project item, HashMap<PluginWrapper, JobsPerPlugin> mapJobsPerPlugin)
+	protected void doJobAnalyze(AbstractProject item, HashMap<PluginWrapper, JobsPerPlugin> mapJobsPerPlugin)
 	{		
 		super.doJobAnalyze(null, mapJobsPerPlugin);
 		Map<TriggerDescriptor,Trigger> triggers = item.getTriggers();


### PR DESCRIPTION
Problem: "Plugin usage" plugin does not report on Maven projects
... since data is only collected for items that are instances of
class hudson.model.Project. But a "Maven project" is **not** (an instance of) a Project.

Solution:
- globally replace _hudson.model.Project_ with _hudson.model.AbstractProject_
- fix up analyzers that call methods that really only work on a _Project_,
  either by ignoring items that aren't _Project_ s (_BuilderJobAnalyzer_)
  or by using another method that works on a wider range of items
  (_BuildWrapperJobAnalyzer_)