### PR TITLE
List all plugins, also not used by jobs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/JobCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/JobCollector.java
@@ -27,7 +27,8 @@ public class JobCollector {
 	public HashMap<PluginWrapper, JobsPerPlugin> getJobsPerPlugin()
 	{
 		HashMap<PluginWrapper, JobsPerPlugin> mapJobsPerPlugin = new HashMap<PluginWrapper, JobsPerPlugin>();
-		List<AbstractProject> allItems = Jenkins.getInstance().getAllItems(AbstractProject.class);
+		Jenkins jenkins = Jenkins.getInstance();
+		List<AbstractProject> allItems = jenkins.getAllItems(AbstractProject.class);
 		
 		for(AbstractProject item: allItems)
 		{
@@ -36,6 +37,16 @@ public class JobCollector {
 				analyser.doJobAnalyze(item, mapJobsPerPlugin);
 			}
 		}
+
+		List<PluginWrapper> allPlugins = jenkins.getPluginManager().getPlugins();
+		for(PluginWrapper plugin: allPlugins)
+		{
+			if (mapJobsPerPlugin.get(plugin) == null)
+			{
+				mapJobsPerPlugin.put(plugin, new JobsPerPlugin(plugin));
+			}
+		}
+
 		return mapJobsPerPlugin;
 	}
 	


### PR DESCRIPTION
In case of pipeline jobs, the plugins were not listed because there is no way for Jenkins to know what plugins are used in those jobs. 
This PR adds all the plugins to the list.
In next PR, there should be a clear info that "Number of jobs" does not count pipeline jobs.