### PR TITLE
Split plugins list considering if a plugin is a dependency of another or not.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pluginusage/PluginUsageModel.java
+++ b/src/main/java/org/jenkinsci/plugins/pluginusage/PluginUsageModel.java
@@ -11,16 +11,31 @@ import org.jenkinsci.plugins.pluginusage.analyzer.JobCollector;
 public class PluginUsageModel {
 
 	private JobCollector JC;
+	private Map<PluginWrapper, JobsPerPlugin> pluginsWithJobs;
+	private Map<PluginWrapper, JobsPerPlugin> pluginsWithJobsDependencies;
+	private List<PluginWrapper> otherPlugins;
+	private List<PluginWrapper> otherPluginsDependencies;
 
 	public PluginUsageModel(){
 		JC = new JobCollector();
+		pluginsWithJobs = JC.getJobsPerPlugin();
+		pluginsWithJobsDependencies = JC.splitByDependencies(pluginsWithJobs);
+		otherPlugins = JC.getOtherPlugins();
+		otherPluginsDependencies = JC.removeDependencies(otherPlugins);
 	}
 	
 	public List<JobsPerPlugin> getJobsPerPlugin() {
 		ArrayList<JobsPerPlugin> list = new ArrayList<JobsPerPlugin>();
-		Map<PluginWrapper, JobsPerPlugin> jobs = JC.getJobsPerPlugin();
-		JC.removeDependencies(jobs);
-		list.addAll(jobs.values());
+		//get a copy of pluginsWithJobs and then sort it.
+		list.addAll(pluginsWithJobs.values());
+		list.sort(Comparator.comparing(JobsPerPlugin::getPluginName));
+		return list;
+	}
+
+	public List<JobsPerPlugin> getDependenciesPerPlugin() {
+		ArrayList<JobsPerPlugin> list = new ArrayList<JobsPerPlugin>();
+		//get a copy of pluginsWithJobsDependencies and then sort it.
+		list.addAll(pluginsWithJobsDependencies.values());
 		list.sort(Comparator.comparing(JobsPerPlugin::getPluginName));
 		return list;
 	}
@@ -31,8 +46,17 @@ public class PluginUsageModel {
 	}
 	
 	public List<PluginWrapper> getOtherPlugins(){
-		List<PluginWrapper> plugins = JC.getOtherPlugins();
-		JC.removeDependencies(plugins);
+		List<PluginWrapper> plugins = new ArrayList<PluginWrapper>();
+		//get a copy of otherPlugins and sort it
+		plugins.addAll(otherPlugins);
+		plugins.sort(Comparator.comparing(PluginWrapper::getLongName));
+		return plugins;
+	}
+
+    public List<PluginWrapper> getOtherDependencies(){
+		List<PluginWrapper> plugins = new ArrayList<PluginWrapper>();
+		//get a copy of otherPluginsDependencies and sort it
+		plugins.addAll(otherPluginsDependencies);
 		plugins.sort(Comparator.comparing(PluginWrapper::getLongName));
 		return plugins;
 	}

--- a/src/main/java/org/jenkinsci/plugins/pluginusage/PluginUsageModel.java
+++ b/src/main/java/org/jenkinsci/plugins/pluginusage/PluginUsageModel.java
@@ -3,26 +3,36 @@ package org.jenkinsci.plugins.pluginusage;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 
 import hudson.PluginWrapper;
 import org.jenkinsci.plugins.pluginusage.analyzer.JobCollector;
 
 public class PluginUsageModel {
+
+	private JobCollector JC;
+
+	public PluginUsageModel(){
+		JC = new JobCollector();
+	}
 	
 	public List<JobsPerPlugin> getJobsPerPlugin() {
 		ArrayList<JobsPerPlugin> list = new ArrayList<JobsPerPlugin>();
-		list.addAll(new JobCollector().getJobsPerPlugin().values());
+		Map<PluginWrapper, JobsPerPlugin> jobs = JC.getJobsPerPlugin();
+		JC.removeDependencies(jobs);
+		list.addAll(jobs.values());
 		list.sort(Comparator.comparing(JobsPerPlugin::getPluginName));
 		return list;
 	}
 	
 	public int getNumberOfJobs()
 	{
-		return new JobCollector().getNumberOfJobs();
+		return JC.getNumberOfJobs();
 	}
 	
 	public List<PluginWrapper> getOtherPlugins(){
-		List<PluginWrapper> plugins = new JobCollector().getOtherPlugins();
+		List<PluginWrapper> plugins = JC.getOtherPlugins();
+		JC.removeDependencies(plugins);
 		plugins.sort(Comparator.comparing(PluginWrapper::getLongName));
 		return plugins;
 	}

--- a/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/JobCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/JobCollector.java
@@ -62,17 +62,10 @@ public class JobCollector {
 		return allItems.size();	
 	}
 
-
-    public List<PluginWrapper> getOtherPlugins() {
-		List<PluginWrapper> allPlugins = Jenkins.get().getPluginManager().getPlugins();
-		List<PluginWrapper> others = new ArrayList<>(allPlugins);
-		List<String> isDependency = new ArrayList<>();
+	public void removeDependencies (List<PluginWrapper> listOfPlugins){
 		List<PluginWrapper> pluginsToRemove = new ArrayList<>();
-
-		for(JobAnalyzer analyser: analysers)
-		{
-			others.removeAll(analyser.getPlugins());
-		}
+		List<String> isDependency = new ArrayList<>();
+		List<PluginWrapper> allPlugins = Jenkins.get().getPluginManager().getPlugins();
 
 		// get a single list of all the plugins that are dependency of another plugin		
 		for(PluginWrapper plugin: allPlugins)
@@ -84,13 +77,13 @@ public class JobCollector {
 			}
 		}
 
-		LOGGER.info("this jobs are dependency of another: " + isDependency);
+		//LOGGER.info("this jobs are dependency of another: " + isDependency);
 
 		//now I want to remove plugins that are dependency of another plugin
-		for(PluginWrapper plugin: others)
+		for(PluginWrapper plugin: listOfPlugins)
 		{
 			String pluginName = plugin.getShortName();
-			LOGGER.info("checking for "+pluginName);	
+			//LOGGER.info("checking for "+pluginName);	
 			if(isDependency.contains(pluginName))
 			{
 				LOGGER.info("this plugin: " + pluginName +" is dependency of another");
@@ -100,7 +93,21 @@ public class JobCollector {
 			}
 		}
 
-		others.removeAll(pluginsToRemove);
+		listOfPlugins.removeAll(pluginsToRemove);
+
+	}
+
+
+    public List<PluginWrapper> getOtherPlugins() {
+		List<PluginWrapper> allPlugins = Jenkins.get().getPluginManager().getPlugins();
+		List<PluginWrapper> others = new ArrayList<>(allPlugins);
+
+		for(JobAnalyzer analyser: analysers)
+		{
+			others.removeAll(analyser.getPlugins());
+		}
+
+		removeDependencies(others);
 
 		return others;
     }

--- a/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/JobCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/JobCollector.java
@@ -70,7 +70,6 @@ public class JobCollector {
 			}
 		}
 
-		removeDependencies(mapJobsPerPlugin);
 		return mapJobsPerPlugin;
 	}
 	
@@ -80,15 +79,12 @@ public class JobCollector {
 	}
 
     public List<PluginWrapper> getOtherPlugins() {
-		List<PluginWrapper> allPlugins = Jenkins.get().getPluginManager().getPlugins();
 		List<PluginWrapper> others = new ArrayList<>(allPlugins);
 
 		for(JobAnalyzer analyser: analysers)
 		{
 			others.removeAll(analyser.getPlugins());
 		}
-
-		removeDependencies(others);
 
 		return others;
     }

--- a/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/JobCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/JobCollector.java
@@ -1,12 +1,14 @@
 package org.jenkinsci.plugins.pluginusage.analyzer;
 
 import hudson.PluginWrapper;
+
 import hudson.model.AbstractProject;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 
 import hudson.model.Job;
 import jenkins.model.Jenkins;
@@ -15,6 +17,7 @@ import org.jenkinsci.plugins.pluginusage.JobsPerPlugin;
 
 public class JobCollector {
 	
+	private static final Logger LOGGER = Logger.getLogger(JobCollector.class.getName());
 	private ArrayList<JobAnalyzer> analysers = new ArrayList<>();
 	
 	public JobCollector() {
@@ -39,15 +42,17 @@ public class JobCollector {
 		}
 
 		List<Job> allItems = Jenkins.get().getAllItems(Job.class);
-		
 		for(Job item: allItems)
 		{
 			for(JobAnalyzer analyser: analysers)
 			{
-				analyser.doJobAnalyze(item, mapJobsPerPlugin);
+				try{
+					analyser.doJobAnalyze(item, mapJobsPerPlugin);
+				} catch(Exception e){
+					LOGGER.warning("Exception catched: " + e );
+				}
 			}
 		}
-
 		return mapJobsPerPlugin;
 	}
 	

--- a/src/main/resources/org/jenkinsci/plugins/pluginusage/PluginUsageView/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pluginusage/PluginUsageView/index.jelly
@@ -9,11 +9,13 @@
             <j:set var="pluginsByJob" value="${data.pluginUsageByPlugin}"/>
             <j:set var="jobsPerPlugin" value="${data.jobsPerPlugin}"/>
             <j:set var="numberOfJobs" value="${data.numberOfJobs}"/>
+            <j:set var="DependenciesPerPlugin" value="${data.DependenciesPerPlugin}"/>
             <j:set var="count" value="0"/>
             ${%Number of Jobs}: ${numberOfJobs}
             <br/>
             <hr/>
-            <h1>${%Jobs by Plugin}</h1>
+            <h1>${%Top level Plugins}</h1>
+            <h3>${%This plugins are not needed by other plugins}</h3>
             <table class="sortable pane bigtable" border="solid #bbb;" id="PluginUsageTable">
                 <thead>
                     <tr>
@@ -59,11 +61,90 @@
                  </tbody>
             </table>
 
+            <h1>${%Dependencies Plugin}</h1>
+            <h3>${%This plugins are dependency of another plugins}</h3>
+            <table class="sortable pane bigtable" border="solid #bbb;" id="DependenciesUsageTable">
+                <thead>
+                    <tr>
+                        <th>
+                            ${%Plugin Name}
+                        </th>
+                        <th>
+                            ${%Version}
+                        </th>
+                        <th>
+                            ${%Number of Jobs}
+                        </th>
+                        <th>
+                            ${%Jobs}
+                        </th>
+                    </tr>
+                </thead>
+                <tbody id="DependenciesUsageTableBody">
+                 <j:forEach var="j" items="${DependenciesPerPlugin}">
+                    <tr>
+                        <td align="center" style="vertical-align:middle;">
+                            <a href="${j.plugin.url}">${j.pluginName}</a>
+                        </td>
+                        <td align="center" style="vertical-align:middle;">
+                            ${j.pluginVersion}
+                        </td>
+                        <td align="center" style="vertical-align:middle;">
+                            ${j.numberOfJobs}
+                        </td>
+                        <td style="padding:5px 15px 5px 5px;">
+                          <j:if test="${j.numberOfJobs > 0}">
+                              <input type="button" name="exco" id="exco${count}" value="expand" onclick="showHide(ulID${count},exco${count})" style="display: block;margin: auto;"/>
+                              <ul id="ulID${count}" style="display:none">
+                                  <j:forEach var="project" items="${j.projects}">
+                                      <li><a href="${app.rootUrl}${project.url}">${project.fullDisplayName}</a></li>
+                                  </j:forEach>
+                              </ul>
+                             <j:set var="count" value="${count+1}"/>
+                          </j:if>
+                        </td>
+                    </tr>
+                 </j:forEach>
+                 </tbody>
+            </table>
+
             <j:set var="data" value="${it.data}"/>
             <j:set var="otherPlugins" value="${data.otherPlugins}"/>
             <br/>
             <hr/>
+            <h1>${%Top level Other Plugins}</h1>
+            <h3>${%This plugins are not dependency of another plugins, also have no job related}</h3>
+            <table class="sortable pane bigtable" border="solid #bbb;">
+                <thead>
+                    <tr>
+                        <th>
+                            ${%Plugin Name}
+                        </th>
+                        <th>
+                            ${%Version}
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <j:forEach var="j" items="${otherPlugins}">
+                        <tr>
+                            <td align="center" style="vertical-align:middle;">
+                                <a href="${j.url}">${j.longName}</a>
+                            </td>
+                            <td align="center" style="vertical-align:middle;">
+                                ${j.version}
+                            </td>
+                        </tr>
+                    </j:forEach>
+                </tbody>
+            </table>
+
+            <j:set var="data" value="${it.data}"/>
+            <j:set var="otherPlugins" value="${data.OtherDependencies}"/>
+            <br/>
+            <hr/>
             <h1>${%Other Plugins}</h1>
+            <h3>${%This plugins are dependency of another plugins, also have no job related}</h3>
             <table class="sortable pane bigtable" border="solid #bbb;">
                 <thead>
                     <tr>


### PR DESCRIPTION
Some plugins have no jobs associated, but they can't be removed because they are dependency of another plugin.
This version of the plugin shows you the "top level plugins", plugins that are not dependency of another, and therefor, a good candidate to be deleted safely.