### PR TITLE
Adds analyzer for pipelines (scripted and declarative) based on last runs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/JobCollector.java
+++ b/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/JobCollector.java
@@ -33,7 +33,8 @@ public class JobCollector {
                         new MavenProjectAnalyzer(),
                         new PipelineProjectAnalyzer(),
                         new MatrixProjectAnalyzer(),
-                        new ComputedFolderAnalyzer());
+                        new ComputedFolderAnalyzer(),
+                        new PipelineLastBuildAnalyzer());
 
         // bootstrap map with all job related plugins
         for(AbstractProjectAnalyzer analyzer: analyzers)

--- a/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/PipelineLastBuildAnalyzer.java
+++ b/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/PipelineLastBuildAnalyzer.java
@@ -1,0 +1,99 @@
+package org.jenkinsci.plugins.pluginusage.analyzer;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import hudson.PluginWrapper;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import hudson.model.Item;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.structs.SymbolLookup;
+import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
+import org.jenkinsci.plugins.workflow.actions.ArgumentsAction;
+import org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode;
+import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.steps.CoreStep;
+import org.jenkinsci.plugins.workflow.steps.CoreWrapperStep;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+
+public class PipelineLastBuildAnalyzer extends AbstractProjectAnalyzer {
+
+    private final boolean hasPlugin;
+
+    public PipelineLastBuildAnalyzer() {
+        this.hasPlugin = Jenkins.get().getPlugin("pipeline-model-definition") != null;
+    }
+
+    @Override
+    protected Set<PluginWrapper> getPluginsFromBuilders(Item item) {
+        final Set<PluginWrapper> plugins = new HashSet<>();
+
+        if (!hasPlugin) {
+            return plugins;
+        }
+
+        if (item instanceof WorkflowJob){
+            final WorkflowJob workflowJob = (WorkflowJob) item;
+            processRun(plugins, workflowJob.getLastBuild());
+            processRun(plugins, workflowJob.getLastSuccessfulBuild());
+            processRun(plugins, workflowJob.getLastCompletedBuild());
+            processRun(plugins, workflowJob.getLastStableBuild());
+        }
+        return plugins;
+    }
+
+    private void processRun(Set<PluginWrapper> plugins, WorkflowRun lastBuild) {
+        if (lastBuild == null) {
+            return;
+        }
+        final FlowExecution execution = lastBuild.getExecution();
+        if (execution == null) {
+            return;
+        }
+        final List<FlowNode> currentHeads = execution.getCurrentHeads();
+
+        final DepthFirstScanner depthFirstScanner = new DepthFirstScanner();
+        depthFirstScanner.visitAll(currentHeads, f -> {
+            if (f instanceof StepStartNode){
+                final StepStartNode startNode = (StepStartNode) f;
+                final StepDescriptor stepDescriptor = startNode.getDescriptor();
+                plugins.add(getPluginFromClass(stepDescriptor.clazz));
+            }
+            if (f instanceof StepAtomNode){
+                final StepAtomNode stepAtomNode = (StepAtomNode) f;
+                final StepDescriptor stepDescriptor = stepAtomNode.getDescriptor();
+                plugins.add(getPluginFromClass(stepDescriptor.clazz));
+
+                if (stepDescriptor.isMetaStep()) {
+                    if (stepDescriptor instanceof CoreStep.DescriptorImpl) {
+                        coreStepProcess(plugins, f);
+                    }
+                    if (stepDescriptor instanceof CoreWrapperStep.DescriptorImpl) {
+                        coreStepProcess(plugins, f);
+                    }
+                }
+            }
+            return true;
+        });
+    }
+
+    private void coreStepProcess(Set<PluginWrapper> plugins, FlowNode f) {
+        final Map<String, Object> arguments = ArgumentsAction.getFilteredArguments(f);
+        if (arguments.get("delegate") instanceof UninstantiatedDescribable) {
+            final UninstantiatedDescribable describable = (UninstantiatedDescribable) arguments.get("delegate");
+            if (describable != null) {
+                final Descriptor<?> descriptor = SymbolLookup.get()
+                        .findDescriptor(Describable.class, describable.getSymbol());
+                plugins.add(getPluginFromClass(descriptor.clazz));
+            }
+        }
+    }
+}

--- a/src/test/resources/scripted-pipeline.xml
+++ b/src/test/resources/scripted-pipeline.xml
@@ -1,0 +1,19 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<flow-definition plugin="workflow-job@1145.v7f2433caa07f">
+    <actions/>
+    <description></description>
+    <keepDependencies>false</keepDependencies>
+    <properties/>
+    <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2660.vb_c0412dc4e6d">
+        <script>node {
+            stage(&apos;build&apos;){
+            sh &apos;echo foo&apos;
+            junit allowEmptyResults: true, testResults: &apos;**/target/surefire-reports/TEST-*.xml&apos;
+            vb6 &apos;project1.vbp&apos;
+            }
+            }</script>
+        <sandbox>true</sandbox>
+    </definition>
+    <triggers/>
+    <disabled>false</disabled>
+</flow-definition>


### PR DESCRIPTION
This may duplicate a bit of work with existing PipelineProjectAnalyzer but that is OK.

Searches only latest builds to keep the information more up to date and for faster response. Considers multiple type of last build because some may have not completed and provide incomplete information.

Attempts to solve [JENKINS-70356 Add option to mark plugin as in use](https://issues.jenkins.io/browse/JENKINS-70356) and [JENKINS-67243 Enhancing with Pipeline Plugin Usage](https://issues.jenkins.io/browse/JENKINS-67243)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
