### PR TITLE
Add null check for old descriptors that are not available anymore

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/PipelineLastBuildAnalyzer.java
+++ b/src/main/java/org/jenkinsci/plugins/pluginusage/analyzer/PipelineLastBuildAnalyzer.java
@@ -65,12 +65,16 @@ class PipelineLastBuildAnalyzer extends AbstractProjectAnalyzer {
             if (f instanceof StepStartNode){
                 final StepStartNode startNode = (StepStartNode) f;
                 final StepDescriptor stepDescriptor = startNode.getDescriptor();
-                plugins.add(getPluginFromClass(stepDescriptor.clazz));
+                if (stepDescriptor != null) {
+                    plugins.add(getPluginFromClass(stepDescriptor.clazz));
+                }
             }
             if (f instanceof StepAtomNode){
                 final StepAtomNode stepAtomNode = (StepAtomNode) f;
                 final StepDescriptor stepDescriptor = stepAtomNode.getDescriptor();
-                plugins.add(getPluginFromClass(stepDescriptor.clazz));
+                if (stepDescriptor != null) {
+                    plugins.add(getPluginFromClass(stepDescriptor.clazz));
+                }
 
                 if (stepDescriptor.isMetaStep()) {
                     if (stepDescriptor instanceof CoreStep.DescriptorImpl) {


### PR DESCRIPTION
Happened with `org.jenkinsci.plugins.workflow.steps.PushdStep` that was moved from `workflow-basic-steps-plugin` to `org.jenkinsci.plugins.workflow.support.steps.PushdStep` in `workflow-durable-task-step-plugin`

https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/258 
https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/293

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] ~~Link to relevant issues in GitHub or Jira~~
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~ (to test this would requires simulating upgrading jenkins plugins in a test) 
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
