### PR TITLE
Use versions from plugin BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.83</version>
+    <version>4.87</version>
   </parent>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>conditional-buildstep</artifactId>
+      <version>1.2</version>
       <optional>true</optional>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,19 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.20.1</version>
+      <version>1.16.0</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <!-- provided by jackson2-api, pulled in transitively through promoted-builds -->
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>conditional-buildstep</artifactId>
-      <version>1.2</version>
       <optional>true</optional>
     </dependency>
 
@@ -40,7 +39,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>promoted-builds</artifactId>
-      <version>3.2</version>
       <optional>true</optional>
     </dependency>
 
@@ -53,7 +51,6 @@
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>maven-plugin</artifactId>
-      <version>3.0</version>
       <optional>true</optional>
     </dependency>
 
@@ -66,19 +63,8 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.16.0</version>
+      <version>1.20.1</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-        <!-- provided by jackson2-api, pulled in transitively through promoted-builds -->
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-annotations</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,8 @@
   </parent>
 
   <properties>
-    <java.version>11</java.version>
-    <jenkins.version>2.440.3</jenkins.version>
+    <jenkins.baseline>2.440</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
   </properties>
 
   <name>Plugin Usage - Plugin</name>
@@ -92,8 +92,8 @@
       </dependency>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.440.x</artifactId>
-        <version>3105.v672692894683</version>
+        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+        <version>3307.v2769886db_63b_</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Use plugin versions from plugin BOM

Better to rely on the compatibility testing of the plugin BOM than to maintain the version numbers in the plugin pom directly.

Use most recent version of testcontainers

Retain old conditional-buildstep version because there is a breaking change in later releases.  If tests pass on ci.jenkins.io with these changes, I can evaluate the difficulty of handling the breaking change in the conditional-buildstep 

### Testing done

Unit tests pass.  Integration tests seem to hang on my Debian and Ubuntu computers.  Will rely on ci.jenkins.io to run the integration tests.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
