### PR TITLE
style: Move Summary to top

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/pluginusage/PluginUsageView/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pluginusage/PluginUsageView/index.jelly
@@ -56,8 +56,9 @@
                         </td>
                         <td style="padding:5px 15px 5px 5px;">
                           <j:if test="${j.numberOfJobs > 0}">
-                              <details class="jenkins-button jenkins-button--tertiary" >
-                                  <ul>
+                              <details class="jenkins-button jenkins-button--tertiary" style="display: block;">
+                                  <summary style="margin-bottom: 10px;">${%Details}</summary>
+                                  <ul style="margin-top: 5px;">
                                       <j:forEach var="project" items="${j.projects}">
                                           <li><a href="${app.rootUrl}${project.url}">${project.fullDisplayName}</a></li>
                                       </j:forEach>

--- a/src/main/resources/org/jenkinsci/plugins/pluginusage/PluginUsageView/index_de.properties
+++ b/src/main/resources/org/jenkinsci/plugins/pluginusage/PluginUsageView/index_de.properties
@@ -5,3 +5,4 @@ Number\ of\ Jobs=Anzahl von Jobs
 up=aufsteigend
 down=absteigend
 Jobs=Jobs
+Details=Details

--- a/src/main/resources/org/jenkinsci/plugins/pluginusage/PluginUsageView/index_fr.properties
+++ b/src/main/resources/org/jenkinsci/plugins/pluginusage/PluginUsageView/index_fr.properties
@@ -5,3 +5,4 @@ Number\ of\ Jobs=Nombre de projets
 up=haut
 down=bas
 Jobs=Projets
+Details=D\u00E9tails

--- a/src/main/resources/org/jenkinsci/plugins/pluginusage/PluginUsageView/index_ja.properties
+++ b/src/main/resources/org/jenkinsci/plugins/pluginusage/PluginUsageView/index_ja.properties
@@ -5,3 +5,4 @@ Number\ of\ Jobs=\u30b8\u30e7\u30d6\u6570
 up=\u964d\u9806
 down=\u6607\u9806
 Jobs=\u30b8\u30e7\u30d6
+Details=\u8A73\u7D30


### PR DESCRIPTION
Prior to this change, the summary was on the left, centered vertically.

This change moves it to the top, so finding it becomes easier when there are many jobs.

<details>
<summary>Before</summary>

<img width="3440" height="1984" alt="image" src="https://github.com/user-attachments/assets/25971093-86f8-4c7a-a922-9b10be6537d2" />

</details>

<details>
<summary>After</summary>

<img width="3440" height="1984" alt="image" src="https://github.com/user-attachments/assets/f611dc47-0a35-4f78-a404-c33ab81e63ab" />

</details>